### PR TITLE
ci: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,8 +64,10 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    uses: KevinDeBenedetti/github-workflows/.github/workflows/release.yml@4dd2b01e64a758b51bfd3d2395130cac8920a6b4 # v0.12.0
+    uses: KevinDeBenedetti/github-workflows/.github/workflows/release.yml@v0.13.0
     with:
       config-file: release/release-please-config-release.json
       manifest-file: release/.release-please-manifest.json
-    secrets: inherit
+      app-client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Switch release-please to a GitHub App token instead of the default `GITHUB_TOKEN`.

- Pass `app-client-id` (from `vars.RELEASE_APP_CLIENT_ID`) and `APP_PRIVATE_KEY`
  (from `secrets.RELEASE_APP_PRIVATE_KEY`) to the reusable `release.yml`.
- The release PR is now opened by the App instead of `github-actions[bot]`,
  which removes the manual "approve workflow" gate and lets CI run on the
  release PR.

Requires the GitHub App installed on this repo with contents / pull-requests /
issues: write, plus the `RELEASE_APP_CLIENT_ID` variable and
`RELEASE_APP_PRIVATE_KEY` secret (already set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
